### PR TITLE
feat: Google/Kakao OAuth 로그인 기능 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 
     // Security & JWT
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'

--- a/backend/src/main/java/com/todo/config/AppProperties.java
+++ b/backend/src/main/java/com/todo/config/AppProperties.java
@@ -1,0 +1,14 @@
+package com.todo.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.oauth2")
+public class AppProperties {
+    private String authorizedRedirectUri;
+}

--- a/backend/src/main/java/com/todo/config/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/todo/config/OAuth2SuccessHandler.java
@@ -1,0 +1,81 @@
+package com.todo.config;
+
+import com.todo.entity.Member;
+import com.todo.repository.MemberRepository;
+import com.todo.entity.RefreshToken;
+import com.todo.repository.RefreshTokenRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final AppProperties appProperties;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+            Authentication authentication) throws IOException, ServletException {
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+        // 이메일 추출 (Google vs Kakao)
+        String email = extractEmail(oAuth2User);
+
+        log.info("OAuth2 로그인 성공: email={}", email);
+
+        // JWT 토큰 생성
+        String accessToken = jwtTokenProvider.generateAccessToken(authentication);
+        String refreshToken = jwtTokenProvider.generateRefreshToken();
+
+        // Refresh Token 저장
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("회원 정보를 찾을 수 없습니다."));
+
+        RefreshToken refreshTokenEntity = RefreshToken.builder()
+                .id(member.getId().toString())
+                .refreshToken(refreshToken)
+                .expiration(jwtTokenProvider.getRefreshTokenValidity())
+                .build();
+        refreshTokenRepository.save(refreshTokenEntity);
+
+        // 프론트엔드로 리다이렉트 (토큰 포함)
+        String targetUrl = UriComponentsBuilder.fromUriString(appProperties.getAuthorizedRedirectUri())
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .build().toUriString();
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+    private String extractEmail(OAuth2User oAuth2User) {
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        // Google
+        if (attributes.containsKey("email")) {
+            return (String) attributes.get("email");
+        }
+
+        // Kakao
+        if (attributes.containsKey("kakao_account")) {
+            Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+            return (String) kakaoAccount.get("email");
+        }
+
+        throw new RuntimeException("이메일을 추출할 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/com/todo/entity/Member.java
+++ b/backend/src/main/java/com/todo/entity/Member.java
@@ -25,7 +25,7 @@ public class Member {
     @Column(nullable = false, unique = true)
     private String email;
 
-    @Column(nullable = false)
+    @Column(nullable = true) // OAuth 로그인 시 비밀번호 없음
     private String password;
 
     @Column(nullable = false)
@@ -35,6 +35,13 @@ public class Member {
     @Column(nullable = false)
     private Role role;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Provider provider = Provider.LOCAL;
+
+    @Column
+    private String providerId;
+
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;
@@ -43,14 +50,26 @@ public class Member {
     private LocalDateTime updatedAt;
 
     @Builder
-    public Member(String email, String password, String nickname, Role role) {
+    public Member(String email, String password, String nickname, Role role, Provider provider, String providerId) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.role = role != null ? role : Role.USER;
+        this.provider = provider != null ? provider : Provider.LOCAL;
+        this.providerId = providerId;
+    }
+
+    // OAuth 계정 연동
+    public void linkOAuthAccount(Provider provider, String providerId) {
+        this.provider = provider;
+        this.providerId = providerId;
     }
 
     public enum Role {
         USER, ADMIN
+    }
+
+    public enum Provider {
+        LOCAL, GOOGLE, KAKAO
     }
 }

--- a/backend/src/main/java/com/todo/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/todo/service/CustomOAuth2UserService.java
@@ -1,0 +1,88 @@
+package com.todo.service;
+
+import com.todo.entity.Member;
+import com.todo.entity.Member.Provider;
+import com.todo.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        Provider provider = Provider.valueOf(registrationId.toUpperCase());
+
+        String providerId;
+        String email;
+        String nickname;
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        if (provider == Provider.GOOGLE) {
+            providerId = (String) attributes.get("sub");
+            email = (String) attributes.get("email");
+            nickname = (String) attributes.get("name");
+        } else if (provider == Provider.KAKAO) {
+            providerId = String.valueOf(attributes.get("id"));
+            Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+            Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+            email = (String) kakaoAccount.get("email");
+            nickname = (String) profile.get("nickname");
+        } else {
+            throw new OAuth2AuthenticationException("Unsupported provider: " + registrationId);
+        }
+
+        log.info("OAuth2 로그인 시도: provider={}, email={}, nickname={}", provider, email, nickname);
+
+        // 기존 회원 조회 (이메일 기준)
+        Optional<Member> existingMember = memberRepository.findByEmail(email);
+
+        Member member;
+        if (existingMember.isPresent()) {
+            member = existingMember.get();
+            // 기존 계정에 OAuth 연동
+            if (member.getProvider() == Provider.LOCAL) {
+                member.linkOAuthAccount(provider, providerId);
+                log.info("기존 계정과 OAuth 연동: email={}", email);
+            }
+        } else {
+            // 신규 회원 생성
+            member = Member.builder()
+                    .email(email)
+                    .nickname(nickname)
+                    .role(Member.Role.USER)
+                    .provider(provider)
+                    .providerId(providerId)
+                    .build();
+            memberRepository.save(member);
+            log.info("OAuth 신규 회원 생성: email={}", email);
+        }
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new org.springframework.security.core.authority.SimpleGrantedAuthority(
+                        "ROLE_" + member.getRole().name())),
+                attributes,
+                userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint()
+                        .getUserNameAttributeName());
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -37,3 +37,30 @@ jwt:
 spring.data.redis:
   host: localhost
   port: 6379
+
+# OAuth2 설정
+spring.security.oauth2.client:
+  registration:
+    google:
+      client-id: ${GOOGLE_CLIENT_ID:your-google-client-id}
+      client-secret: ${GOOGLE_CLIENT_SECRET:your-google-client-secret}
+      scope: email, profile
+    kakao:
+      client-id: ${KAKAO_CLIENT_ID:your-kakao-client-id}
+      client-secret: ${KAKAO_CLIENT_SECRET:your-kakao-client-secret}
+      scope: profile_nickname, account_email
+      authorization-grant-type: authorization_code
+      redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+      client-authentication-method: client_secret_post
+      client-name: Kakao
+  provider:
+    kakao:
+      authorization-uri: https://kauth.kakao.com/oauth/authorize
+      token-uri: https://kauth.kakao.com/oauth/token
+      user-info-uri: https://kapi.kakao.com/v2/user/me
+      user-name-attribute: id
+
+# OAuth2 콜백 후 프론트엔드 리다이렉트 URL
+app:
+  oauth2:
+    authorized-redirect-uri: http://localhost:3000/auth/oauth/callback

--- a/frontend-next/app/auth/login/page.tsx
+++ b/frontend-next/app/auth/login/page.tsx
@@ -6,6 +6,8 @@ import Link from 'next/link';
 import { login } from '@/lib/api';
 import { useAuthStore } from '@/store/useAuthStore';
 
+const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+
 export default function LoginPage() {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
@@ -32,6 +34,10 @@ export default function LoginPage() {
         } finally {
             setLoading(false);
         }
+    };
+
+    const handleOAuthLogin = (provider: 'google' | 'kakao') => {
+        window.location.href = `${BACKEND_URL}/oauth2/authorization/${provider}`;
     };
 
     return (
@@ -88,6 +94,46 @@ export default function LoginPage() {
                         </button>
                     </div>
                 </form>
+
+                {/* 소셜 로그인 구분선 */}
+                <div className="relative">
+                    <div className="absolute inset-0 flex items-center">
+                        <div className="w-full border-t border-gray-300 dark:border-gray-700" />
+                    </div>
+                    <div className="relative flex justify-center text-sm">
+                        <span className="bg-gray-50 px-2 text-gray-500 dark:bg-gray-900 dark:text-gray-400">
+                            Or continue with
+                        </span>
+                    </div>
+                </div>
+
+                {/* 소셜 로그인 버튼 */}
+                <div className="grid grid-cols-2 gap-3">
+                    <button
+                        type="button"
+                        onClick={() => handleOAuthLogin('google')}
+                        className="flex w-full items-center justify-center gap-2 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+                    >
+                        <svg className="h-5 w-5" viewBox="0 0 24 24">
+                            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
+                            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+                            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+                            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+                        </svg>
+                        Google
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => handleOAuthLogin('kakao')}
+                        className="flex w-full items-center justify-center gap-2 rounded-md bg-[#FEE500] px-3 py-2 text-sm font-semibold text-[#000000] shadow-sm hover:bg-[#FDD800]"
+                    >
+                        <svg className="h-5 w-5" viewBox="0 0 24 24">
+                            <path fill="#000000" d="M12 3c5.799 0 10.5 3.664 10.5 8.185 0 4.52-4.701 8.184-10.5 8.184a13.5 13.5 0 0 1-1.727-.11l-4.408 2.883c-.501.265-.678.236-.472-.413l.892-3.678c-2.88-1.46-4.785-3.99-4.785-6.866C1.5 6.665 6.201 3 12 3z" />
+                        </svg>
+                        Kakao
+                    </button>
+                </div>
+
                 <div className="text-center text-sm">
                     <p className="text-gray-600 dark:text-gray-400">
                         Don't have an account?{' '}

--- a/frontend-next/app/auth/oauth/callback/page.tsx
+++ b/frontend-next/app/auth/oauth/callback/page.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useAuthStore } from '@/store/useAuthStore';
+
+export default function OAuthCallbackPage() {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const loginUser = useAuthStore((state) => state.login);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const accessToken = searchParams.get('accessToken');
+        const refreshToken = searchParams.get('refreshToken');
+
+        if (accessToken && refreshToken) {
+            // JWT 토큰을 파싱하여 사용자 정보 추출
+            try {
+                const payload = JSON.parse(atob(accessToken.split('.')[1]));
+                const user = {
+                    email: payload.sub,
+                    nickname: payload.nickname || payload.sub.split('@')[0],
+                    role: payload.role || 'USER'
+                };
+
+                loginUser(user, accessToken, refreshToken);
+                router.push('/');
+            } catch (err) {
+                setError('토큰 파싱 중 오류가 발생했습니다.');
+            }
+        } else {
+            setError('OAuth 인증에 실패했습니다.');
+        }
+    }, [searchParams, loginUser, router]);
+
+    if (error) {
+        return (
+            <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
+                <div className="text-center">
+                    <p className="text-red-500">{error}</p>
+                    <button
+                        onClick={() => router.push('/auth/login')}
+                        className="mt-4 rounded-md bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-500"
+                    >
+                        로그인 페이지로 돌아가기
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
+            <div className="text-center">
+                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+                <p className="mt-4 text-gray-600 dark:text-gray-400">로그인 처리 중...</p>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## 📝 어떤 기능을 추가/수정 했나요?
Google과 Kakao 소셜 로그인 기능을 추가했습니다.

## 🛠️ 작업 상세 내용
- Spring Security OAuth2 Client 종속성 추가
- Member 엔티티에 provider, providerId 필드 추가
- CustomOAuth2UserService 구현 (이메일 기반 계정 연동)
- OAuth2SuccessHandler 구현 (JWT 토큰 발급)
- SecurityConfig에 OAuth2 로그인 설정 추가
- 프론트엔드 로그인 페이지에 Google/Kakao 버튼 추가
- OAuth 콜백 페이지 구현

## ✅ 체크리스트
- [x] 빌드가 성공적으로 수행되었나요?
- [ ] 모든 기능을 직접 테스트 해보셨나요?

> ⚠️ OAuth 테스트를 위해서는 Google Cloud Console과 Kakao Developers에서 앱 등록 및 키 발급이 필요합니다.