### PR TITLE
백엔드 예외 처리 응답 체계 정비 및 테스트 보강

### DIFF
--- a/backend/src/main/java/com/todo/config/JwtTokenProvider.java
+++ b/backend/src/main/java/com/todo/config/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package com.todo.config;
 
+import com.todo.exception.UnauthorizedException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -77,7 +78,7 @@ public class JwtTokenProvider {
         Claims claims = parseClaims(accessToken);
 
         if (claims.get(AUTHORITIES_KEY) == null) {
-            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+            throw new UnauthorizedException("권한 정보가 없는 토큰입니다.");
         }
 
         Collection<? extends GrantedAuthority> authorities = Arrays

--- a/backend/src/main/java/com/todo/config/SecurityConfig.java
+++ b/backend/src/main/java/com/todo/config/SecurityConfig.java
@@ -23,6 +23,8 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final com.todo.exception.CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final com.todo.exception.CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -35,10 +37,14 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/auth/signup", "/api/auth/login", "/api/auth/reissue").permitAll()
                         .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
                         .requestMatchers("/api/todos/**").authenticated()
+                        .requestMatchers("/api/auth/logout").authenticated()
                         .anyRequest().permitAll())
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler))
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                         .successHandler(oAuth2SuccessHandler))

--- a/backend/src/main/java/com/todo/controller/AuthController.java
+++ b/backend/src/main/java/com/todo/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.todo.controller;
 
 import com.todo.dto.AuthRequest;
 import com.todo.dto.AuthResponse;
+import com.todo.exception.UnauthorizedException;
 import com.todo.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -36,6 +37,9 @@ public class AuthController {
 
     @PostMapping("/logout")
     public ResponseEntity<String> logout(@AuthenticationPrincipal UserDetails userDetails) {
+        if (userDetails == null) {
+            throw new UnauthorizedException("인증이 필요합니다.");
+        }
         authService.logout(userDetails.getUsername());
         return ResponseEntity.ok("로그아웃 성공");
     }

--- a/backend/src/main/java/com/todo/exception/CustomAccessDeniedHandler.java
+++ b/backend/src/main/java/com/todo/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,41 @@
+package com.todo.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+            AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        log.error("Access Denied error: {}", accessDeniedException.getMessage());
+
+        GlobalExceptionHandler.ErrorResponse errorResponse = new GlobalExceptionHandler.ErrorResponse(
+                HttpStatus.FORBIDDEN.value(),
+                "접근 권한이 없습니다.",
+                null,
+                LocalDateTime.now());
+
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+    }
+}

--- a/backend/src/main/java/com/todo/exception/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/todo/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,41 @@
+package com.todo.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException authException) throws IOException, ServletException {
+        log.error("Unauthorized error: {}", authException.getMessage());
+
+        GlobalExceptionHandler.ErrorResponse errorResponse = new GlobalExceptionHandler.ErrorResponse(
+                HttpStatus.UNAUTHORIZED.value(),
+                "인증이 필요합니다.",
+                null,
+                LocalDateTime.now());
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+    }
+}

--- a/backend/src/main/java/com/todo/exception/DuplicateResourceException.java
+++ b/backend/src/main/java/com/todo/exception/DuplicateResourceException.java
@@ -1,0 +1,7 @@
+package com.todo.exception;
+
+public class DuplicateResourceException extends RuntimeException {
+    public DuplicateResourceException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/todo/exception/ForbiddenException.java
+++ b/backend/src/main/java/com/todo/exception/ForbiddenException.java
@@ -1,0 +1,7 @@
+package com.todo.exception;
+
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/todo/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/todo/exception/GlobalExceptionHandler.java
@@ -1,8 +1,10 @@
 package com.todo.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -19,6 +21,7 @@ import java.util.Map;
  * - 예외 로깅 및 모니터링
  */
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
     /**
@@ -31,9 +34,12 @@ public class GlobalExceptionHandler {
         
         Map<String, String> errors = new HashMap<>();
         ex.getBindingResult().getAllErrors().forEach(error -> {
-            String fieldName = ((FieldError) error).getField();
             String message = error.getDefaultMessage();
-            errors.put(fieldName, message);
+            if (error instanceof FieldError fieldError) {
+                errors.put(fieldError.getField(), message);
+            } else {
+                errors.put(error.getObjectName(), message);
+            }
         });
 
         ErrorResponse response = new ErrorResponse(
@@ -47,11 +53,11 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * Todo를 찾을 수 없음 (404 Not Found)
+     * 리소스를 찾을 수 없음 (404 Not Found)
      */
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(
-            IllegalArgumentException ex) {
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleResourceNotFoundException(
+            ResourceNotFoundException ex) {
         
         ErrorResponse response = new ErrorResponse(
                 HttpStatus.NOT_FOUND.value(),
@@ -61,6 +67,75 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    /**
+     * 중복 리소스 생성 시도 (409 Conflict)
+     */
+    @ExceptionHandler(DuplicateResourceException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicateResourceException(
+            DuplicateResourceException ex) {
+
+        ErrorResponse response = new ErrorResponse(
+                HttpStatus.CONFLICT.value(),
+                ex.getMessage(),
+                null,
+                LocalDateTime.now()
+        );
+
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
+    }
+
+    /**
+     * 인증 실패 (401 Unauthorized)
+     */
+    @ExceptionHandler({ UnauthorizedException.class, AuthenticationException.class })
+    public ResponseEntity<ErrorResponse> handleUnauthorizedException(Exception ex) {
+        String message = (ex instanceof AuthenticationException)
+                ? "인증에 실패했습니다."
+                : ex.getMessage();
+
+        ErrorResponse response = new ErrorResponse(
+                HttpStatus.UNAUTHORIZED.value(),
+                message,
+                null,
+                LocalDateTime.now()
+        );
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+    }
+
+    /**
+     * 인가 실패 (403 Forbidden)
+     */
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException ex) {
+
+        ErrorResponse response = new ErrorResponse(
+                HttpStatus.FORBIDDEN.value(),
+                ex.getMessage(),
+                null,
+                LocalDateTime.now()
+        );
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
+    }
+
+    /**
+     * 잘못된 요청 파라미터/상태 (400 Bad Request)
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(
+            IllegalArgumentException ex) {
+
+        ErrorResponse response = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                ex.getMessage(),
+                null,
+                LocalDateTime.now()
+        );
+
+        return ResponseEntity.badRequest().body(response);
     }
 
     /**
@@ -75,8 +150,7 @@ public class GlobalExceptionHandler {
                 LocalDateTime.now()
         );
 
-        // 로그 출력 (실제로는 로거 사용)
-        ex.printStackTrace();
+        log.error("Unhandled exception", ex);
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
     }

--- a/backend/src/main/java/com/todo/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/todo/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.todo.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/todo/exception/UnauthorizedException.java
+++ b/backend/src/main/java/com/todo/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.todo.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/test/java/com/todo/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/todo/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,85 @@
+package com.todo.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class GlobalExceptionHandlerTest {
+
+    private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new TestController())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    @DisplayName("유효성 검증 실패 시 400과 errors 필드를 반환한다")
+    void validationError_ShouldReturn400WithErrors() throws Exception {
+        mockMvc.perform(post("/test/validate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ValidateRequest(""))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.errors.text").exists());
+    }
+
+    @Test
+    @DisplayName("AuthenticationException 발생 시 401을 반환한다")
+    void authenticationException_ShouldReturn401() throws Exception {
+        mockMvc.perform(get("/test/auth-fail"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.message").value("인증에 실패했습니다."));
+    }
+
+    @Test
+    @DisplayName("처리되지 않은 예외는 500을 반환한다")
+    void unhandledException_ShouldReturn500() throws Exception {
+        mockMvc.perform(get("/test/error"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.message").value("서버 오류가 발생했습니다"));
+    }
+
+    @RestController
+    static class TestController {
+        @PostMapping("/test/validate")
+        public String validate(@Valid @RequestBody ValidateRequest request) {
+            return "ok";
+        }
+
+        @GetMapping("/test/auth-fail")
+        public String authFail() {
+            throw new BadCredentialsException("bad credentials");
+        }
+
+        @GetMapping("/test/error")
+        public String error() {
+            throw new RuntimeException("unexpected");
+        }
+    }
+
+    record ValidateRequest(@NotBlank String text) {
+    }
+}


### PR DESCRIPTION
## 📝 어떤 기능을 추가/수정 했나요?
예외 처리 정책을 상태코드별로 분리하고, 인증/인가 실패 응답을 일관되게 정비했습니다.

## 🛠️ 작업 상세 내용
- 도메인 예외 타입 추가 (404/409/401/403)
- GlobalExceptionHandler 매핑 개선 및 로깅 정리
- SecurityConfig에 인증/인가 예외 핸들러 연결
- /api/auth/logout 인증 필요 경로로 조정
- Auth/Todo 컨트롤러 예외 응답 테스트 추가
- GlobalExceptionHandler 단위 테스트 추가

## 📸 스크린샷 (선택)
해당 없음

## ✅ 체크리스트
- [x] 빌드가 성공적으로 수행되었나요?
- [x] 모든 기능을 직접 테스트 해보셨나요?