### PR TITLE
ci: split CodeQL scan and security notification workflow

### DIFF
--- a/.github/workflows/security-notify.yml
+++ b/.github/workflows/security-notify.yml
@@ -46,10 +46,17 @@ jobs:
             const commitAlerts = alerts.filter((alert) =>
               alert?.most_recent_instance?.commit_sha === sha
             );
+            const summarizedAlerts = commitAlerts.slice(0, 20).map((alert) => ({
+              severity: alert.rule?.security_severity_level || alert.rule?.severity || 'unknown',
+              rule: alert.rule?.id || alert.rule?.name || 'unknown-rule',
+              path: alert.most_recent_instance?.location?.path || 'unknown-path',
+              line: alert.most_recent_instance?.location?.start_line || '?',
+              url: alert.html_url || ''
+            }));
 
             core.info(`CodeQL findings for ${sha}: ${commitAlerts.length}`);
             core.setOutput('count', String(commitAlerts.length));
-            core.setOutput('alerts', JSON.stringify(commitAlerts));
+            core.setOutput('alerts', JSON.stringify(summarizedAlerts));
             core.setOutput('sha', sha);
             core.setOutput('run_id', String(runId));
             core.setOutput('run_url', runUrl || `https://github.com/${owner}/${repo}/actions/runs/${runId}`);
@@ -59,6 +66,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           ALERTS_JSON: ${{ steps.findings.outputs.alerts }}
+          TOTAL_COUNT: ${{ steps.findings.outputs.count }}
           ANALYZED_SHA: ${{ steps.findings.outputs.sha }}
           ANALYZE_RUN_URL: ${{ steps.findings.outputs.run_url }}
         with:
@@ -71,6 +79,7 @@ jobs:
             const title = `[Security] CodeQL findings on main (${shortSha})`;
             const marker = `<!-- codeql-main-sha:${sha} -->`;
             const alerts = JSON.parse(process.env.ALERTS_JSON || '[]');
+            const totalCount = Number(process.env.TOTAL_COUNT || alerts.length);
 
             const existing = await github.paginate(
               github.rest.issues.listForRepo,
@@ -82,18 +91,18 @@ jobs:
               return;
             }
 
-            const rows = alerts.slice(0, 20).map((a, idx) => {
-              const severity = a.rule?.security_severity_level || a.rule?.severity || 'unknown';
-              const rule = a.rule?.id || a.rule?.name || 'unknown-rule';
-              const path = a.most_recent_instance?.location?.path || 'unknown-path';
-              const line = a.most_recent_instance?.location?.start_line || '?';
-              const html = a.html_url || '';
+            const rows = alerts.map((a, idx) => {
+              const severity = a.severity || 'unknown';
+              const rule = a.rule || 'unknown-rule';
+              const path = a.path || 'unknown-path';
+              const line = a.line || '?';
+              const html = a.url || '';
               return `${idx + 1}. \`${severity}\` \`${rule}\` at \`${path}:${line}\` ([view](${html}))`;
             }).join('\n');
 
             const body = [
               marker,
-              `CodeQL detected **${alerts.length}** open finding(s) tied to commit \`${sha}\` on \`main\`.`,
+              `CodeQL detected **${totalCount}** open finding(s) tied to commit \`${sha}\` on \`main\`.`,
               '',
               `CodeQL run: ${runUrl}`,
               '',
@@ -113,7 +122,7 @@ jobs:
             });
 
       - name: Send Slack notification
-        if: steps.findings.outputs.count != '0' && secrets.SLACK_WEBHOOK_URL != ''
+        if: steps.findings.outputs.count != '0' && env.SLACK_WEBHOOK_URL != ''
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           COUNT: ${{ steps.findings.outputs.count }}


### PR DESCRIPTION
## 📝 어떤 기능을 추가/수정 했나요?
CodeQL 스캔과 보안 알림 로직을 분리해, 스캔 실패/변경이 알림 로직에 직접 영향을 덜 주도록 워크플로우를 개선했습니다.

## 🛠️ 작업 상세 내용
- `codeql.yml`에서 보안 알림 책임을 제거하고 CodeQL 분석 전용으로 정리
- `security-notify.yml` 신규 추가 (`workflow_run` 기반): CodeQL 성공 + `push` + `main` 조건에서만 실행
- 해당 커밋 SHA 기준 CodeQL 오픈 알림 수집 후 GitHub Issue 자동 생성 (`security`, `codeql` 라벨)
- 동일 SHA 마커(`codeql-main-sha`)로 중복 이슈 생성 방지
- `SLACK_WEBHOOK_URL` 시크릿 존재 시 Slack 알림 전송
- 테스트용으로 임시 추가했던 `workflow_dispatch`를 `codeql.yml`에서 제거

## 📸 스크린샷 (선택)
해당 없음 (CI 워크플로우 변경)

## ✅ 체크리스트
- [x] 빌드가 성공적으로 수행되었나요?
- [x] 모든 기능을 직접 테스트 해보셨나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 자동 보안 알림 시스템 추가. CodeQL 분석 완료 후 발견된 보안 이슈에 대해 GitHub 이슈를 자동 생성하고, 중복을 방지하는 메커니즘과 함께 구성된 Slack 웹훅을 통해 팀에 알림을 전송합니다. 상세한 보안 리포트도 함께 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->